### PR TITLE
ajuste da porta e permitir conexão por fora do container

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 
-	lis, err := net.Listen("tcp", "localhost:50051")
+	lis, err := net.Listen("tcp", "0.0.0.0:50051")
 	if err != nil {
 		log.Fatalf("Could not connect: %v", err)
 	}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   app:
     build: .
     ports:
-      - 50021:50021
+      - 50051:50051
     volumes:
       - .:/go/src
   


### PR DESCRIPTION
Ao tentar usar o evans percebi que não estava funcionando ao utilizar o docker-compose

notei que a porta no docker-compose estava diferente e o server só estava aceitando conexão local.

o evans estava executando fora do container.

com esses ajustes está funcionando.